### PR TITLE
Update for Cretonne reloc changes.

### DIFF
--- a/lib/llvm/src/module.rs
+++ b/lib/llvm/src/module.rs
@@ -69,8 +69,11 @@ impl<'a> fmt::Display for DisplayCompiledFunction<'a> {
                 write!(f, "0x{:02x}, ", byte)?;
             }
             write!(f, "\n")?;
-            for &(ref reloc, ref name, ref offset) in &compilation.relocs.relocs {
-                write!(f, "reloc: {}:{}@{}\n", reloc, name, offset)?;
+            for &(ref reloc, ref name, ref offset, addend) in &compilation.relocs.relocs {
+                match addend {
+                    0 => write!(f, "reloc: {}:{}@{}\n", reloc, name, offset)?,
+                    _ => write!(f, "reloc: {}:{}{}@{}\n", reloc, name, addend, offset)?,
+                }
             }
         }
         Ok(())

--- a/lib/llvm/src/reloc_sink.rs
+++ b/lib/llvm/src/reloc_sink.rs
@@ -2,7 +2,7 @@ use cretonne::ir;
 use cretonne::binemit;
 
 pub struct RelocSink {
-    pub relocs: Vec<(binemit::Reloc, ir::ExternalName, binemit::CodeOffset)>,
+    pub relocs: Vec<(binemit::Reloc, ir::ExternalName, binemit::CodeOffset, binemit::Addend)>,
 }
 
 impl RelocSink {
@@ -26,8 +26,12 @@ impl<'func> binemit::RelocSink for RelocSink {
         offset: binemit::CodeOffset,
         reloc: binemit::Reloc,
         name: &ir::ExternalName,
+        addend: binemit::Addend,
     ) {
-        self.relocs.push((reloc, name.clone(), offset));
+        // TODO: How should addend be handled? Should it be added to
+        // offset and stored in self.relocs or carried through beside
+        // offset?
+        self.relocs.push((reloc, name.clone(), offset, addend));
     }
 
     fn reloc_jt(

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -128,12 +128,14 @@ fn handle_module(
                 "faerie define",
             );
             // TODO: reloc should derive from Copy
-            for &(ref reloc, ref external_name, offset) in &compilation.relocs.relocs {
+            for &(ref reloc, ref external_name, offset, addend) in &compilation.relocs.relocs {
                 // FIXME: What about other types of relocs?
                 // TODO: Faerie API: Seems like it might be inefficient to
                 // identify the caller by name each time.
                 // TODO: Faerie API: It's inconvenient to keep track of which
                 // symbols are imports and which aren't.
+                debug_assert!(addend as i32 as i64 == addend);
+                let addend = addend as i32;
                 let name = module.strings.get_str(external_name);
                 obj.link_with(
                     Link {
@@ -143,7 +145,7 @@ fn handle_module(
                     },
                     RelocOverride {
                         elftype: translate_reloc(reloc),
-                        addend: 0,
+                        addend: addend,
                     },
                 ).expect("faerie link");
             }
@@ -179,7 +181,7 @@ fn translate_reloc(reloc: &Reloc) -> u32 {
         Reloc::IntelPCRel4 => elf::reloc::R_X86_64_PC32,
         Reloc::IntelAbs4 => elf::reloc::R_X86_64_32,
         Reloc::IntelAbs8 => elf::reloc::R_X86_64_64,
-        Reloc::IntelGotPCRel4 => elf::reloc::R_X86_64_GOTPCREL,
+        Reloc::IntelGOTPCRel4 => elf::reloc::R_X86_64_GOTPCREL,
         Reloc::IntelPLTRel4 => elf::reloc::R_X86_64_PLT32,
         _ => panic!("unsupported reloc kind"),
     }


### PR DESCRIPTION
As a precursor to starting on clang2cretonne, I've been trying to get llvm2cretonne to compile. These are the last errors I ran into from changes to Cretonne reloc handling.

@sunfishcode, you might already have local changes that fix this, but I've chosen to pass the `addend` along with the `offset` in the `relocs` tuple.  Should `addend` be added to `offset` instead?