### PR TITLE
Reduce clone() usage in StringTable

### DIFF
--- a/lib/llvm/Cargo.toml
+++ b/lib/llvm/Cargo.toml
@@ -13,6 +13,7 @@ name = "cton_llvm"
 [dependencies]
 cretonne = { git = "https://github.com/stoklund/cretonne.git" }
 cretonne-frontend = { git = "https://github.com/stoklund/cretonne.git" }
+fnv = "1.0"
 llvm-sys = "50.0.0"
 libc = "0.2.32"
 ordermap = "0.3.2"

--- a/lib/llvm/src/lib.rs
+++ b/lib/llvm/src/lib.rs
@@ -4,6 +4,7 @@
 
 extern crate cretonne;
 extern crate cton_frontend;
+extern crate fnv;
 extern crate llvm_sys;
 extern crate libc;
 extern crate ordermap;

--- a/lib/llvm/src/string_table.rs
+++ b/lib/llvm/src/string_table.rs
@@ -1,13 +1,16 @@
 use cretonne::ir;
+use fnv::FnvBuildHasher;
 use ordermap::OrderMap;
 
+type FnvOrderSet<T> = OrderMap<T, (), FnvBuildHasher>;
+
 pub struct StringTable {
-    names: OrderMap<String, ()>,
+    names: FnvOrderSet<String>,
 }
 
 impl StringTable {
     pub fn new() -> Self {
-        Self { names: OrderMap::new() }
+        Self { names: FnvOrderSet::default() }
     }
 
     // TODO: Can we avoid returning a clone of the string?

--- a/lib/llvm/src/string_table.rs
+++ b/lib/llvm/src/string_table.rs
@@ -13,18 +13,18 @@ impl StringTable {
         Self { names: FnvOrderSet::default() }
     }
 
-    // TODO: Can we avoid returning a clone of the string?
-    pub fn get_str(&mut self, extname: ir::ExternalName) -> String {
-        match extname {
+    pub fn get_str(&self, extname: &ir::ExternalName) -> &str {
+        match *extname {
             ir::ExternalName::User { namespace, index } => {
                 debug_assert!(namespace == 0, "alternate namespaces not yet implemented");
                 self.names
                     .get_index(index as usize)
                     .expect("name has not yet been declared")
                     .0
+                    .as_str()
             }
             _ => panic!("non-user names not yet implemented"),
-        }.clone()
+        }
     }
 
     // TODO: Can we minimize how often our users have to clone strings?

--- a/lib/llvm/src/translate.rs
+++ b/lib/llvm/src/translate.rs
@@ -94,7 +94,7 @@ pub fn translate_module(
                 let name = &func.il.dfg.ext_funcs[func_ref].name;
                 // If this function is defined inside the module, don't list it
                 // as an import.
-                let c_str = ffi::CString::new(result.strings.get_str(name.clone()))
+                let c_str = ffi::CString::new(result.strings.get_str(name))
                     .map_err(|err| err.description().to_string())?;
                 let llvm_str = c_str.as_ptr();
                 let llvm_func = unsafe { LLVMGetNamedFunction(llvm_mod, llvm_str) };
@@ -106,7 +106,7 @@ pub fn translate_module(
                 if let ir::GlobalVarData::Sym { ref name } = func.il.global_vars[global_var] {
                     // If this global is defined inside the module, don't list it
                     // as an import.
-                    let c_str = ffi::CString::new(result.strings.get_str(name.clone()))
+                    let c_str = ffi::CString::new(result.strings.get_str(name))
                         .map_err(|err| err.description().to_string())?;
                     let llvm_str = c_str.as_ptr();
                     let llvm_global = unsafe { LLVMGetNamedGlobal(llvm_mod, llvm_str) };


### PR DESCRIPTION
@sunfishcode, I saw the comments about the number of `clone()` in string_table.rs so I modified the interface to reduce the need to clone. What do you think?