### PR TITLE
Update cranelift to 0.42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ path = "src/llvm2cranelift.rs"
 
 [dependencies]
 cranelift-llvm = { path = "lib/llvm" }
-cranelift-codegen = "0.15.0"
-cranelift-reader = "0.15.0"
-target-lexicon = "0.0.3"
+cranelift-codegen = "0.42.0"
+cranelift-reader = "0.42.0"
+target-lexicon = "0.8.1"
 docopt = "0.8.3"
 serde = "1.0.27"
 serde_derive = "1.0.27"
-term = "0.4.6"
-faerie = "0.4.3"
+term = "0.6.1"
+faerie = "0.11.0"
 goblin = "0.0.14"
 
 [workspace]

--- a/lib/llvm/Cargo.toml
+++ b/lib/llvm/Cargo.toml
@@ -11,8 +11,8 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift_llvm"
 
 [dependencies]
-cranelift-codegen = "0.15.0"
-cranelift-frontend = "0.15.0"
+cranelift-codegen = "0.42.0"
+cranelift-frontend = "0.42.0"
 fnv = "1.0.6"
 llvm-sys = "50.0.3"
 libc = "0.2.36"

--- a/lib/llvm/src/context.rs
+++ b/lib/llvm/src/context.rs
@@ -3,30 +3,11 @@
 use cranelift_codegen;
 use cranelift_codegen::ir;
 use cranelift_frontend;
+use cranelift_frontend::Variable;
 use llvm_sys::prelude::*;
 use llvm_sys::target::*;
 use std::collections::HashMap;
 use std::u32;
-
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub struct Variable(pub u32);
-impl cranelift_codegen::entity::EntityRef for Variable {
-    fn new(index: usize) -> Self {
-        debug_assert!(index < (u32::MAX as usize));
-        Variable(index as u32)
-    }
-
-    fn index(self) -> usize {
-        self.0 as usize
-    }
-}
-
-impl Variable {
-    pub fn new(i: usize) -> Self {
-        debug_assert_eq!(i as u32 as usize, i);
-        Variable(i as u32)
-    }
-}
 
 /// Information about Ebbs that we'll create.
 pub struct EbbInfo {
@@ -42,7 +23,7 @@ impl Default for EbbInfo {
 /// Data structures used throughout translation.
 pub struct Context<'a> {
     /// Builder for emitting instructions.
-    pub builder: cranelift_frontend::FunctionBuilder<'a, Variable>,
+    pub builder: cranelift_frontend::FunctionBuilder<'a>,
 
     /// Map from LLVM Values to `Variable`s.
     pub value_map: HashMap<LLVMValueRef, Variable>,
@@ -62,11 +43,11 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     pub fn new(
         func: &'a mut ir::Function,
-        il_builder: &'a mut cranelift_frontend::FunctionBuilderContext<Variable>,
+        il_builder: &'a mut cranelift_frontend::FunctionBuilderContext,
         dl: LLVMTargetDataRef,
     ) -> Self {
         Self {
-            builder: cranelift_frontend::FunctionBuilder::<Variable>::new(func, il_builder),
+            builder: cranelift_frontend::FunctionBuilder::new(func, il_builder),
             value_map: HashMap::new(),
             ebb_info: HashMap::new(),
             ebb_map: HashMap::new(),

--- a/lib/llvm/src/context.rs
+++ b/lib/llvm/src/context.rs
@@ -1,13 +1,11 @@
 //! Translation state.
 
-use cranelift_codegen;
 use cranelift_codegen::ir;
 use cranelift_frontend;
 use cranelift_frontend::Variable;
 use llvm_sys::prelude::*;
 use llvm_sys::target::*;
 use std::collections::HashMap;
-use std::u32;
 
 /// Information about Ebbs that we'll create.
 pub struct EbbInfo {

--- a/lib/llvm/src/reloc_sink.rs
+++ b/lib/llvm/src/reloc_sink.rs
@@ -39,6 +39,10 @@ impl<'func> binemit::RelocSink for RelocSink {
         self.relocs.push((reloc, name.clone(), offset, addend));
     }
 
+    fn reloc_constant(&mut self, _: binemit::CodeOffset, _: binemit::Reloc, _: ir::ConstantOffset) {
+        panic!("reloc_constant not yet implemented");
+    }
+
     fn reloc_jt(
         &mut self,
         _offset: binemit::CodeOffset,

--- a/lib/llvm/src/translate.rs
+++ b/lib/llvm/src/translate.rs
@@ -115,10 +115,9 @@ pub fn translate_module(
             }
             for global_var in func.il.global_values.keys() {
                 // TODO: Use the colocated field.
-                let offset0 = ir::immediates::Imm64::new(0);
                 if let ir::GlobalValueData::Symbol {
                     ref name,
-                    offset: offset0,
+                    offset: _offset,
                     colocated: _colocated,
                 } = func.il.global_values[global_var]
                 {

--- a/lib/llvm/src/translate.rs
+++ b/lib/llvm/src/translate.rs
@@ -1,7 +1,7 @@
 //! Translation from LLVM IR to Cranelift IL.
 
 use cranelift_codegen;
-use cranelift_codegen::binemit::NullTrapSink;
+use cranelift_codegen::binemit::{NullTrapSink, NullStackmapSink};
 use cranelift_codegen::ir;
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_frontend;
@@ -18,7 +18,7 @@ use std::ptr;
 use std::str;
 use string_table::StringTable;
 
-use context::{Context, EbbInfo, Variable};
+use context::{Context, EbbInfo};
 use module::{Compilation, CompiledFunction, DataSymbol, Module, SymbolKind};
 use operations::{translate_function_params, translate_inst};
 use reloc_sink::RelocSink;
@@ -115,8 +115,10 @@ pub fn translate_module(
             }
             for global_var in func.il.global_values.keys() {
                 // TODO: Use the colocated field.
-                if let ir::GlobalValueData::Sym {
+                let offset0 = ir::immediates::Imm64::new(0);
+                if let ir::GlobalValueData::Symbol {
                     ref name,
+                    offset: offset0,
                     colocated: _colocated,
                 } = func.il.global_values[global_var]
                 {
@@ -208,7 +210,7 @@ pub fn translate_function(
         translate_sig(unsafe { LLVMGetElementType(LLVMTypeOf(llvm_func)) }, dl);
 
     {
-        let mut il_builder = cranelift_frontend::FunctionBuilderContext::<Variable>::new();
+        let mut il_builder = cranelift_frontend::FunctionBuilderContext::new();
         let mut ctx = Context::new(&mut clif_ctx.func, &mut il_builder, dl);
 
         // Make a pre-pass through the basic blocks to collect predecessor
@@ -228,14 +230,15 @@ pub fn translate_function(
     }
 
     if let Some(isa) = isa {
-        let code_size = clif_ctx.compile(isa).map_err(|err| err.to_string())?;
+        let code_size = clif_ctx.compile(isa).map_err(|err| err.to_string())?.code_size;
         let mut code_buf: Vec<u8> = Vec::with_capacity(code_size as usize);
         let mut reloc_sink = RelocSink::new();
         let mut trap_sink = NullTrapSink {};
+        let mut stackmap_sink = NullStackmapSink {};
         code_buf.resize(code_size as usize, 0);
         // TODO: Use the safe interface instead.
         unsafe {
-            clif_ctx.emit_to_memory(isa, code_buf.as_mut_ptr(), &mut reloc_sink, &mut trap_sink);
+            clif_ctx.emit_to_memory(isa, code_buf.as_mut_ptr(), &mut reloc_sink, &mut trap_sink, &mut stackmap_sink);
         }
 
         Ok(CompiledFunction {

--- a/lib/llvm/src/types.rs
+++ b/lib/llvm/src/types.rs
@@ -1,7 +1,7 @@
 //! Translate types from LLVM IR to Cranelift IL.
 
 use cranelift_codegen::ir;
-use cranelift_codegen::settings::CallConv;
+use cranelift_codegen::isa::CallConv;
 use llvm_sys::core::*;
 use llvm_sys::prelude::*;
 use llvm_sys::target::*;
@@ -28,7 +28,7 @@ pub fn translate_pointer_type(dl: LLVMTargetDataRef) -> ir::Type {
 /// Translate an LLVM first-class type into a Cranelift type.
 pub fn translate_type(llvm_ty: LLVMTypeRef, dl: LLVMTargetDataRef) -> ir::Type {
     match unsafe { LLVMGetTypeKind(llvm_ty) } {
-        LLVMVoidTypeKind => ir::types::VOID,
+        LLVMVoidTypeKind => ir::types::INVALID,
         LLVMHalfTypeKind => panic!("unimplemented: f16 type"),
         LLVMFloatTypeKind => ir::types::F32,
         LLVMDoubleTypeKind => ir::types::F64,
@@ -77,7 +77,7 @@ pub fn translate_sig(llvm_ty: LLVMTypeRef, dl: LLVMTargetDataRef) -> ir::Signatu
 
     let mut returns: Vec<ir::AbiParam> = Vec::with_capacity(1);
     match translate_type(unsafe { LLVMGetReturnType(llvm_ty) }, dl) {
-        ir::types::VOID => {}
+        ir::types::INVALID => {}
         ty => returns.push(ir::AbiParam::new(ty)),
     }
     sig.returns = returns;

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -5,7 +5,7 @@
 use cranelift_codegen::binemit::Reloc;
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_llvm::{create_llvm_context, read_llvm, translate_module, SymbolKind};
-use faerie::{Artifact, Decl, ImportKind, Link, RelocOverride};
+use faerie::{Artifact, Decl, ImportKind, Link};
 use goblin::elf;
 use std::fmt::format;
 use std::path::Path;
@@ -96,7 +96,7 @@ fn handle_module(
         }
     } else {
         let isa: &TargetIsa = isa.expect("compilation requires a target isa");
-
+        
         let mut obj = Artifact::new(isa.triple().clone(), String::from(arg_output));
 
         for import in &module.imports {
@@ -109,17 +109,14 @@ fn handle_module(
             // FIXME: non-global functions.
             obj.declare(
                 module.strings.get_str(&func.il.name),
-                Decl::Function { global: true },
+                Decl::function().global(),
             ).expect("faerie declare");
         }
         // FIXME: non-global and non-writeable data.
         for data in &module.data_symbols {
             obj.declare(
                 module.strings.get_str(&data.name),
-                Decl::Data {
-                    global: true,
-                    writeable: true,
-                },
+                faerie::Decl::data().global().with_writable(true),
             ).expect("faerie declare");
         }
         for func in module.functions {
@@ -143,7 +140,7 @@ fn handle_module(
                         to: &name,
                         at: u64::from(offset),
                     },
-                    RelocOverride {
+                    faerie::Reloc::Raw {
                         reloc: translate_reloc(reloc),
                         addend: addend,
                     },

--- a/src/llvm.rs
+++ b/src/llvm.rs
@@ -141,7 +141,7 @@ fn handle_module(
                     Link {
                         from: &func_name,
                         to: &name,
-                        at: offset as usize,
+                        at: u64::from(offset),
                     },
                     RelocOverride {
                         reloc: translate_reloc(reloc),


### PR DESCRIPTION
I'm currently experiment with this project and cranelift.
Before evaluate it further I decided to update it to use the latest cranelift version.

- are there any tests to make sure I did not introduce any bugs?
- especially I'm worried about the new `offset` field in `GlobalValueData::Symbol` 
I'm currently just setting it to 0.
- there may be stupid mistakes because I'm totally new to rust...
