### PR TITLE
symbols: put data symbols into namespace 1 and funcs into 0

### DIFF
--- a/lib/llvm/src/string_table.rs
+++ b/lib/llvm/src/string_table.rs
@@ -5,22 +5,26 @@ use indexmap::IndexMap;
 type FnvIndexSet<T> = IndexMap<T, (), FnvBuildHasher>;
 
 pub struct StringTable {
-    names: FnvIndexSet<String>,
+    names: [FnvIndexSet<String>; 2],
 }
 
 impl StringTable {
     pub fn new() -> Self {
         Self {
-            names: FnvIndexSet::default(),
+            names: [FnvIndexSet::default(), FnvIndexSet::default()],
         }
+    }
+
+    pub fn get_ns(&self, is_func: bool) -> u32 {
+        if is_func { 0 } else { 1 }
     }
 
     /// Return the string name for a given cranelift `ExternalName`.
     pub fn get_str(&self, extname: &ir::ExternalName) -> &str {
         match *extname {
             ir::ExternalName::User { namespace, index } => {
-                debug_assert!(namespace == 0, "alternate namespaces not yet implemented");
-                self.names
+                debug_assert!(namespace == 0 || namespace == 1, "alternate namespaces not yet implemented");
+                self.names[namespace as usize]
                     .get_index(index as usize)
                     .expect("name has not yet been declared")
                     .0
@@ -31,15 +35,16 @@ impl StringTable {
     }
 
     /// Enter a string name into the table.
-    pub fn declare_extname<S: Into<String>>(&mut self, string: S) {
-        let previous = self.names.insert(string.into(), ());
+    pub fn declare_extname<S: Into<String>>(&mut self, string: S, is_func: bool) {
+        let previous = self.names[self.get_ns(is_func) as usize].insert(string.into(), ());
         debug_assert!(previous.is_none());
     }
 
     /// Return the cranelift `ExternalName` for a given string name.
-    pub fn get_extname<S: Into<String>>(&self, string: S) -> ir::ExternalName {
-        let index = self.names.get_full(&string.into()).unwrap().0;
+    pub fn get_extname<S: Into<String>>(&self, string: S, is_func: bool) -> ir::ExternalName {
+        let namespace = self.get_ns(is_func);
+        let index = self.names[namespace as usize].get_full(&string.into()).unwrap().0;
         debug_assert!(index as u32 as usize == index);
-        ir::ExternalName::user(0, index as u32)
+        ir::ExternalName::user(namespace, index as u32)
     }
 }


### PR DESCRIPTION
Before this change we but everything into namespace 0 (so is_function() always returned true).
`cranelift-simplejit/src/backend.rs::get_definition:`
calls `namespace.is_function(name)` to figure out if it has to lookup a function or data definition.
But cranelift-module is_function() does this by comparing the namespace with 0:
```rust
    // Return whether `name` names a function, rather than a data object.
    pub fn is_function(&self, name: &ir::ExternalName) -> bool {
        if let ir::ExternalName::User { namespace, .. } = *name {
            namespace == 0
        } else {
            panic!("unexpected ExternalName kind {}", name)
        }
    }