### PR TITLE
fix crash when encountering a comparison with 'null' or non inst values (e.g. llvm::ConstExpressions)

### DIFF
--- a/lib/llvm/src/operations.rs
+++ b/lib/llvm/src/operations.rs
@@ -1100,6 +1100,11 @@ fn binary_operands_r_ri(
     let llvm_rhs_type = unsafe { LLVMTypeOf(llvm_rhs) };
     if unsafe { LLVMGetIntTypeWidth(llvm_rhs_type) } == 1 {
         RegImmOperands::Bool(lhs, use_val(llvm_rhs, ctx, strings))
+    } else if unsafe { LLVMIsNull(llvm_rhs) } != 0 {
+        RegImmOperands::RegImm(
+            lhs,
+            ir::immediates::Imm64::from(0),
+        )
     } else if unsafe { LLVMIsConstant(llvm_rhs) } != 0 {
         RegImmOperands::RegImm(
             lhs,

--- a/lib/llvm/src/operations.rs
+++ b/lib/llvm/src/operations.rs
@@ -1105,7 +1105,9 @@ fn binary_operands_r_ri(
             lhs,
             ir::immediates::Imm64::from(0),
         )
-    } else if unsafe { LLVMIsConstant(llvm_rhs) } != 0 {
+    } else if unsafe { LLVMIsConstant(llvm_rhs) } != 0
+        && unsafe { LLVMGetValueKind(llvm_rhs) } == LLVMConstantIntValueKind
+    {
         RegImmOperands::RegImm(
             lhs,
             ir::immediates::Imm64::from(unsafe { LLVMConstIntGetZExtValue(llvm_rhs) } as i64),


### PR DESCRIPTION
before this fix
```llvm
define i32 @foo(i8*) {
  %2 = icmp ne i8* %0, null
  %3 = zext i1 %2 to i32
  ret i32 %3
 }

```
either crashed or just inserted a random value (e.g 33 in my case):
```
; foo
function u0:0(i64) -> i32 system_v {
ebb0(v0: i64):
    v1 = icmp_imm ne v0, 33
    v2 = bint.i32 v1
    return v2
}
```